### PR TITLE
Juste remove a point in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Installation
 
 Download ''fireplace.el'' and place it somewhere in your ''.emacs.d'' directory, say in ''.emacs.d/fireplace/''.
 Compile the file using ''M-x byte-compile-file''.
-Put ''(load "~./.emacs.d/fireplace/fireplace") in your init file ('.emacs').
+Put ''(load "~./emacs.d/fireplace/fireplace") in your init file ('.emacs').
 Note that there is a significant performance difference bewteen the compiled and non-compiled fireplace.
 
 You can start the fire using ''M-x fireplace''.

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Installation
 
 Download ''fireplace.el'' and place it somewhere in your ''.emacs.d'' directory, say in ''.emacs.d/fireplace/''.
 Compile the file using ''M-x byte-compile-file''.
-Put ''(load "~./emacs.d/fireplace/fireplace") in your init file ('.emacs').
+Put ''(load "~/.emacs.d/fireplace/fireplace") in your init file ('.emacs').
 Note that there is a significant performance difference bewteen the compiled and non-compiled fireplace.
 
 You can start the fire using ''M-x fireplace''.


### PR DESCRIPTION
Before :

> (load "~./.emacs.d/fireplace/fireplace")

After :

> (load "~/.emacs.d/fireplace/fireplace")
