### PR TITLE
Fix wrong-number-of-arguments error

### DIFF
--- a/fireplace.el
+++ b/fireplace.el
@@ -180,7 +180,7 @@
   (transient-mark-mode nil)
   (buffer-disable-undo))
 
-(defun fireplace--update-locals-vars ()
+(defun fireplace--update-locals-vars (&optional frame)
   "Update `fireplace' local variables."
   (setq fireplace--bkgd-height (- (floor (window-height (get-buffer-window fireplace-buffer-name))) 1)
         fireplace--bkgd-width  (- (round (window-width (get-buffer-window fireplace-buffer-name))) 1)


### PR DESCRIPTION
`fireplace--update-locals-vars' is also called with an (ignored) FRAME
parameter when added to`window-size-change-functions'. Fixes  #22.

Thanks for making Emacs a homely place :fire: 
