### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -42,5 +42,4 @@
 	    (:report-file "/tmp/undercover-report.json"))
 (require 'fireplace)
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Fixes #24.