### PR TITLE
Keep fire from getting out of control, minor changes

### DIFF
--- a/fireplace.el
+++ b/fireplace.el
@@ -114,7 +114,7 @@
   (goto-char (+ 1 x (* (- fireplace--bkgd-height (+ 1 y))
                        (+ 1 fireplace--bkgd-width)))))
 
-(defun draw-flame-stripe (x y width)
+(defun fireplace--draw-flame-stripe (x y width)
   "Draw flame stripe."
   (fireplace--gotoxy x y)
   (let* ((actual-width (min width (1+ (- fireplace--bkgd-width x))))
@@ -155,7 +155,7 @@
               x 0))
       (when (> (+ x width) fireplace--bkgd-width)
         (setq width (- fireplace--bkgd-width x)))
-      (draw-flame-stripe x y width))
+      (fireplace--draw-flame-stripe x y width))
     (dotimes (y high)
       (setq line (+ lower y)
             width (max 0 (- width 1 (random 3)))
@@ -165,7 +165,7 @@
               x 0))
       (when (> (+ x width) fireplace--bkgd-width)
         (setq width (- fireplace--bkgd-width x)))
-      (draw-flame-stripe x line width)
+      (fireplace--draw-flame-stripe x line width)
       (when fireplace-smoke-on (fireplace--smoke x h)))))
 
 (defun fireplace-draw (buffer-name)

--- a/fireplace.el
+++ b/fireplace.el
@@ -229,13 +229,18 @@
 
 ;;; Key-bindings
 
-(define-derived-mode fireplace-mode special-mode  "A cozy fireplace.")
+(defvar fireplace-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-+") 'fireplace-up)
+    (define-key map (kbd "C--") 'fireplace-down)
+    (define-key map (kbd "C-*") 'fireplace-toggle-smoke)
+    (define-key map (kbd "q") 'fireplace-off)
+    (define-key map (kbd "Q") 'fireplace-off)
+    map)
+  "Keymap for `fireplace-mode'.")
 
-(define-key fireplace-mode-map (kbd "C-+") 'fireplace-up)
-(define-key fireplace-mode-map (kbd "C--") 'fireplace-down)
-(define-key fireplace-mode-map (kbd "C-*") 'fireplace-toggle-smoke)
-(define-key fireplace-mode-map (kbd "q") 'fireplace-off)
-(define-key fireplace-mode-map (kbd "Q") 'fireplace-off)
+(define-derived-mode fireplace-mode special-mode  "A cozy fireplace."
+  "Major mode for *fireplace* buffers.")
 
 (provide 'fireplace)
 ;;; fireplace.el ends here

--- a/fireplace.el
+++ b/fireplace.el
@@ -196,6 +196,10 @@
         fireplace--flame-width (min fireplace--bkgd-height (round (/ fireplace--bkgd-width 2.5)))
         fireplace--flame-pos fireplace-flame-pos))
 
+(defun fireplace--extinguish-flames ()
+  "Cancel the `fireplace-draw' timer."
+  (cancel-function-timers 'fireplace-draw))
+
 ;; Commands
 
 ;;;###autoload
@@ -208,15 +212,13 @@
     (fireplace-mode)
     (add-hook 'window-size-change-functions 'fireplace--update-locals-vars nil t)
     (fireplace--disable-minor-modes)
-    (setq fireplace--timer
-          (run-with-timer 1 (- 1 fireplace-fury)
-                          'fireplace-draw fireplace-buffer-name))))
+    (run-with-timer 1 (- 1 fireplace-fury) 'fireplace-draw fireplace-buffer-name)))
 
 (defun fireplace-off ()
   "Put out the fire."
   (interactive)
-  (when fireplace--timer
-    (cancel-timer fireplace--timer)
+  (fireplace--extinguish-flames)
+  (when (get-buffer fireplace-buffer-name)
     (kill-buffer fireplace-buffer-name)))
 
 (defun fireplace-down ()

--- a/fireplace.el
+++ b/fireplace.el
@@ -171,13 +171,15 @@
 (defun fireplace-draw (buffer-name)
   "Draw the whole fireplace in BUFFER-NAME from FLAME-POS with FLAME-WIDTH."
   (with-current-buffer (get-buffer-create buffer-name)
-    (setq buffer-read-only nil)
-    (fireplace--make-grid)
-    (dolist (pos fireplace--flame-pos)
-      (fireplace--flame (round (* pos fireplace--bkgd-width))
-       (+ (round (* (+ 0.2 (min pos (- 1 pos))) fireplace--flame-width))
-          (random 3))))
-    (setq buffer-read-only t)))
+    (if (not (eq major-mode 'fireplace-mode))
+        (fireplace-off)
+      (setq buffer-read-only nil)
+      (fireplace--make-grid)
+      (dolist (pos fireplace--flame-pos)
+        (fireplace--flame (round (* pos fireplace--bkgd-width))
+                          (+ (round (* (+ 0.2 (min pos (- 1 pos))) fireplace--flame-width))
+                             (random 3))))
+      (setq buffer-read-only t))))
 
 (defun fireplace--disable-minor-modes ()
   "Disable minor modes that might affect rendering."

--- a/fireplace.el
+++ b/fireplace.el
@@ -23,7 +23,8 @@
 
 ;;; Commentary:
 
-;; Puts your Emacs on fire
+;; Oh, the weather outside is frightful!
+;; But the fire is so delightful...
 
 ;;; Code:
 

--- a/fireplace.el
+++ b/fireplace.el
@@ -105,7 +105,7 @@
 (defun fireplace--make-grid ()
   "Redraw backgound of buffer."
   (erase-buffer)
-  (dotimes (i fireplace--bkgd-height)
+  (dotimes (_ fireplace--bkgd-height)
     (insert-char fireplace-background-char fireplace--bkgd-width)
     (newline)))
 
@@ -190,7 +190,7 @@
   (transient-mark-mode nil)
   (buffer-disable-undo))
 
-(defun fireplace--update-locals-vars (&optional frame)
+(defun fireplace--update-locals-vars ()
   "Update `fireplace' local variables."
   (setq fireplace--bkgd-height (- (floor (window-height (get-buffer-window fireplace-buffer-name))) 1)
         fireplace--bkgd-width  (- (round (window-width (get-buffer-window fireplace-buffer-name))) 1)
@@ -200,9 +200,9 @@
 ;; Commands
 
 ;;;###autoload
-(defun fireplace (arg)
+(defun fireplace ()
   "Light the fire."
-  (interactive "P")
+  (interactive)
   (with-current-buffer (get-buffer-create fireplace-buffer-name)
     (fireplace--update-locals-vars)
     (fireplace--make-grid)

--- a/fireplace.el
+++ b/fireplace.el
@@ -207,7 +207,7 @@
     (fireplace--update-locals-vars)
     (fireplace--make-grid)
     (fireplace-mode)
-    (add-hook 'window-size-change-functions 'fireplace--update-locals-vars)
+    (add-hook 'window-size-change-functions 'fireplace--update-locals-vars nil t)
     (fireplace--disable-minor-modes)
     (setq fireplace--timer
           (run-with-timer 1 (- 1 fireplace-fury)
@@ -216,7 +216,6 @@
 (defun fireplace-off ()
   "Put out the fire."
   (interactive)
-  (remove-hook 'window-size-change-functions 'fireplace--update-locals-vars)
   (when fireplace--timer
     (cancel-timer fireplace--timer)
     (kill-buffer fireplace-buffer-name)))

--- a/fireplace.el
+++ b/fireplace.el
@@ -185,7 +185,6 @@
   (setq truncate-lines t
         cursor-type nil
         show-trailing-whitespace nil
-        show-leading-whitespace nil
         indicate-empty-lines nil)
   (transient-mark-mode nil)
   (buffer-disable-undo))

--- a/fireplace.el
+++ b/fireplace.el
@@ -29,11 +29,11 @@
 ;;; Code:
 
 (defgroup fireplace nil
-  "Config for `fireplace' ."
+  "Config for `fireplace'."
   :group 'applications)
 
-
 ;; User definable Variables
+
 (defcustom fireplace-smoke-on nil
   "Controls if smoke is drawn of not."
   :type 'string :group 'fireplace)
@@ -58,12 +58,12 @@
   "Relative position and order for drawing flames."
   :type '(list float) :group 'fireplace)
 
-
 (defcustom fireplace-buffer-name  "*fireplace*"
   "Default name for fireplace buffer."
   :type 'string :group 'fireplace)
 
 ;;; Faces
+
 (defgroup fireplace-faces nil
   "Faces for `fireplace'."
   :group 'fireplace)
@@ -77,20 +77,26 @@
   '((t (:background "dark orange")))
   "Color of the core of the flame."
   :group 'fireplace-faces)
+
 (defface fireplace-smoke-face
   '((t (:foreground "slate grey")))
   "Color of the smoke."
   :group 'fireplace-faces)
 
 ;;; Program controlled variables
+
 (defvar fireplace--bkgd-height nil
   "Used for fireplace height, will be set from windows size")
+
 (defvar fireplace--bkgd-width nil
   "Used for fireplace width, will be set from windows size")
+
 (defvar fireplace--timer nil
   "Holds the active fireplace, kill using fireplace-off")
+
 (defvar fireplace--flame-width nil
   "Calculated width of flames")
+
 (defvar fireplace--flame-pos nil
   "Flame position")
 
@@ -103,11 +109,10 @@
     (insert-char fireplace-background-char fireplace--bkgd-width)
     (newline)))
 
-(defun fireplace--gotoxy(x y)
+(defun fireplace--gotoxy (x y)
   "Move pointer to position X Y."
   (goto-char (+ 1 x (* (- fireplace--bkgd-height (+ 1 y))
                        (+ 1 fireplace--bkgd-width)))))
-
 
 (defun draw-flame-stripe (x y width)
   "Draw flame stripe."
@@ -116,23 +121,23 @@
          (hot-core (/ actual-width 2)))
     (delete-char actual-width)
     (insert (propertize (make-string actual-width fireplace-fill-char)
-      'face 'fireplace-outter-flame-face))
+                        'face 'fireplace-outter-flame-face))
     (when (> hot-core 1)
       (fireplace--gotoxy (+ x (/ hot-core 2)) y)
       (delete-char hot-core)
       (insert (propertize (make-string hot-core fireplace-fill-char)
-              'face 'fireplace-inner-flame-face)))))
+                          'face 'fireplace-inner-flame-face)))))
 
 (defun fireplace--smoke (x height)
   "Draw one random smoke."
   (fireplace--gotoxy
-    (if (>(random 3) 1)
-        (+ x (random (/ fireplace--bkgd-width 5)))
-        (max 0 (- x (random (/ fireplace--bkgd-width 5)))))
-    (+ height (random (- fireplace--bkgd-height height))))
+   (if (>(random 3) 1)
+       (+ x (random (/ fireplace--bkgd-width 5)))
+     (max 0 (- x (random (/ fireplace--bkgd-width 5)))))
+   (+ height (random (- fireplace--bkgd-height height))))
   (delete-char 1)
   (insert (propertize (make-string 1 fireplace-smoke-char)
-          'face 'fireplace-smoke-face)))
+                      'face 'fireplace-smoke-face)))
 
 (defun fireplace--flame (middle h)
   "Draw a flame."
@@ -193,6 +198,7 @@
         fireplace--flame-pos fireplace-flame-pos))
 
 ;; Commands
+
 ;;;###autoload
 (defun fireplace (arg)
   "Light the fire."
@@ -219,7 +225,6 @@
   "Push the fire further down"
   (interactive)
   (setq fireplace--bkgd-height (+ fireplace--bkgd-height 1)))
-
 
 (defun fireplace-up ()
   "Move the fire further up."

--- a/fireplace.el
+++ b/fireplace.el
@@ -83,12 +83,16 @@
   :group 'fireplace-faces)
 
 ;;; Program controlled variables
-(defvar fireplace--bkgd-height "Used for fireplace height, will be set from windows size")
-(defvar fireplace--bkgd-width "Used for fireplace width, will be set from windows size")
-(defvar fireplace--timer "Holds the active fireplace, kill using fireplace-off")
-(defvar fireplace--flame-width "Calculated width of flames")
-(defvar fireplace--flame-pos "Flame position")
-(defvar fireplace--flame-width "Flame width")
+(defvar fireplace--bkgd-height nil
+  "Used for fireplace height, will be set from windows size")
+(defvar fireplace--bkgd-width nil
+  "Used for fireplace width, will be set from windows size")
+(defvar fireplace--timer nil
+  "Holds the active fireplace, kill using fireplace-off")
+(defvar fireplace--flame-width nil
+  "Calculated width of flames")
+(defvar fireplace--flame-pos nil
+  "Flame position")
 
 ;;; Helper routines
 

--- a/test/emacs-fireplace-test.el
+++ b/test/emacs-fireplace-test.el
@@ -12,7 +12,6 @@
 (require 'fireplace)
 
 (ert-deftest test-fire-raging-out-of-control ()
-  :expected-result :failed
   (fireplace)
   (let ((buf (get-buffer "*fireplace*")))
     (should buf)

--- a/test/emacs-fireplace-test.el
+++ b/test/emacs-fireplace-test.el
@@ -3,8 +3,20 @@
 ;;; Commentary:
 ;; These are the tests for `emacs-fireplace'
 
+;; Run with shell command:
+
+;; emacs -Q --batch --directory ./ --directory ./test --load test/emacs-fireplace-test.el --funcall ert-run-tests-batch-and-exit
+
 ;;; Code:
 
-(ert-deftest emacs-fireplace-should-not-pass ()
-  (should-not nil))
+(require 'fireplace)
 
+(ert-deftest test-fire-raging-out-of-control ()
+  :expected-result :failed
+  (fireplace t)
+  (let ((buf (get-buffer "*fireplace*")))
+    (should buf)
+    (kill-buffer buf))
+  (sit-for 2)
+  (let ((buf (get-buffer "*fireplace*")))
+    (should-not buf)))

--- a/test/emacs-fireplace-test.el
+++ b/test/emacs-fireplace-test.el
@@ -13,7 +13,7 @@
 
 (ert-deftest test-fire-raging-out-of-control ()
   :expected-result :failed
-  (fireplace t)
+  (fireplace)
   (let ((buf (get-buffer "*fireplace*")))
     (should buf)
     (kill-buffer buf))


### PR DESCRIPTION
This package is hilarious. I actually came across it when [a picture was posted](https://jezebel.com/1830798203) in a comment thread for a completely non-technical article along with "What a burn!". So congratulations, `fireplace` has hit the mainstream!

Anyway, the main change in this PR is to allow killing the `*fireplace*` buffer directly, without running `fireplace-off`. Previously, killing the buffer would lead an unkillable buffer getting created.

There are also some small code changes, like whitespace cleanup.

Now, time to get cozy...

https://www.youtube.com/watch?v=xJ_qbUwzyLo