### PR TITLE
Fix: Attempted fix for fireplace not resizing easily

### DIFF
--- a/fireplace.el
+++ b/fireplace.el
@@ -201,6 +201,13 @@
               show-trailing-whitespace nil
               indicate-empty-lines nil
               transient-mark-mode nil
+              hl-line-mode nil
+              ;; global-hl-line mode overrides the local hl-line-mode
+              ;; *for some reason* and it's still called global-hl-line-mode
+              ;; *even though* you can set 'global-hl-line-mode' as a buffer-local.
+              global-hl-line-mode nil
+              ;; non-standard emacs packages
+              beacon-mode nil
               )
   ;; Reference the fireplace buffer in-case the current buffer
   ;; isn't the fireplace, for some reason.

--- a/fireplace.el
+++ b/fireplace.el
@@ -195,13 +195,17 @@
 (defun fireplace--disable-minor-modes ()
   "Disable minor modes that might affect rendering."
   (switch-to-buffer fireplace-buffer-name)
-  (setq truncate-lines t
-        cursor-type nil
-        show-trailing-whitespace nil
-        indicate-empty-lines nil)
-  (transient-mark-mode nil)
-  (buffer-disable-undo))
-
+  ;; Use local variables to avoid messing with the actual editing enviornment
+  (setq-local truncate-lines t
+              cursor-type nil
+              show-trailing-whitespace nil
+              indicate-empty-lines nil
+              transient-mark-mode nil
+              )
+  ;; Reference the fireplace buffer in-case the current buffer
+  ;; isn't the fireplace, for some reason.
+  (buffer-disable-undo fireplace-buffer-name)
+  )
 (defun fireplace--update-locals-vars (&optional stub-window)
   "Update `fireplace' local variables."
   (setq fireplace--bkgd-height (- (floor (window-height (get-buffer-window fireplace-buffer-name))) 1)

--- a/fireplace.el
+++ b/fireplace.el
@@ -202,7 +202,7 @@
   (transient-mark-mode nil)
   (buffer-disable-undo))
 
-(defun fireplace--update-locals-vars ()
+(defun fireplace--update-locals-vars (&optional stub-window)
   "Update `fireplace' local variables."
   (setq fireplace--bkgd-height (- (floor (window-height (get-buffer-window fireplace-buffer-name))) 1)
         fireplace--bkgd-width  (- (round (window-width (get-buffer-window fireplace-buffer-name))) 1)


### PR DESCRIPTION
I noticed that my fireplace wasn't resizing dynamically very easily,
and whislt this wasn't really a big deal, I got curious and had a look.
I want my fireplace to be cozy! <3

The actual offending line is rather
Line 244:
 '(add-hook 'window-size-change-functions 'fireplace--update-locals-vars nil t)'
As per the documentation the
'Functions called during redisplay when window sizes have changed.
The value should be a list of functions that take one argument.'

So that's all the problem is, the function is being called with an argument it
isn't expecting, the documentation states it passes the window as an argument.
But here we don't care about that, so I just added a 'stub-window' to 'eat' the
argument.

Although, it occurs to me this might be a bit lazy, and I could quite easily use the passed
argument to update the fileplace vars, instead of searching for the (hardcoded) buffer every time.
But hey, it works.

Also here I used &optional because of that one other time when the
update-vars function is called, but again, this could easily be adaopted
to supply the window context properly.

EDIT:
I should note that I've been using this fix for a solid year or something, by straight overriding the 
function with a nearly identical copy of 7296ced in my 'init.el'.
It should work just fine.